### PR TITLE
Improve sentry messages

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -282,7 +282,7 @@ email_backend = airflow.utils.email.send_email_smtp
 [sentry] 
 # If you want to send logging on retries, failure you need to specify 
 # you sentry key here
-sentry_DSN= https://da5e36de5c7646a9be2c2e5e0ba00986:715ed09781854df7bfd4829f2d3f6d94@sentry.io/143739
+sentry_DSN= https://xxx.@sentry.io/xxx
 sentry_environment = staging
 [smtp]
 # If you want airflow to send emails on retries, failure, and you want to use
@@ -484,7 +484,7 @@ hide_paused_dags_by_default = False
 email_backend = airflow.utils.email.send_email_smtp
 
 [sentry]
-sentry_DSN = https://da5e36de5c7646a9be2c2e5e0ba00986:715ed09781854df7bfd4829f2d3f6d94@sentry.io/143445
+sentry_DSN = https://xxx.@sentry.io/xxx
 sentry_environment = staging
 
 [smtp]

--- a/airflow/contrib/operators/sentry_operator.py
+++ b/airflow/contrib/operators/sentry_operator.py
@@ -26,28 +26,30 @@ class SentryOperator(BaseOperator):
     Notification level is fatal by default
 
     :param message: sentry notification message
-    :type message: string
     :param level: notification level (fatal, error, warning, info, debug)
-    :type level: string
-    :param sentry_kwargs: dict of arguments to raven.Client (eg, "dsn")
-    :param message_kwargs: dict of arguments to sendMessage (eg, "fingerprint")
+    :param tags: dictionary of tag:value pairs
+    :param environment: environment string, eg staging
+    :param extra: dictionary of key:value metadata pairs
+    :param fingerprint: list of strings for use in hierarchically categorising the error
+    :param dsn: Sentry DSN (to allow this operator to be used without [sentry] in airflow.cfg)
     """
 
-    template_fields = ('message', )
+    template_fields = ('message', 'environment', 'tags', 'extra')
     ui_color = '#e6faf9'
 
     @apply_defaults
-    def __init__(self, message, level='info',
-                 sentry_kwargs=None, message_kwargs=None,
-                 *args, **kwargs):
+    def __init__(self, message, level='info', tags=None, environment=None, extra=None,
+                 fingerprint=None, dsn=None, *args, **kwargs):
         super(SentryOperator, self).__init__(*args, **kwargs)
         self.message = message
         self.level = level
-        self.sentry_kwargs = sentry_kwargs
-        self.message_kwargs = message_kwargs
-        if message_kwargs is None:
-            self.message_kwargs = {}
+        self.tags = tags
+        self.environment = environment
+        self.extra = extra
+        self.fingerprint = fingerprint
+        self.dsn = dsn
 
     def execute(self, context):
-        send_msg_to_sentry(message=self.message, level=self.level,
-                           sentry_kwargs=self.sentry_kwargs, **self.message_kwargs)
+        send_msg_to_sentry(message=self.message, level=self.level, tags=self.tags,
+                           environment=self.environment, extra=self.extra,
+                           fingerprint=self.fingerprint, sentry_kwargs=dict(dsn=self.dsn))

--- a/airflow/contrib/operators/sentry_operator.py
+++ b/airflow/contrib/operators/sentry_operator.py
@@ -25,34 +25,29 @@ class SentryOperator(BaseOperator):
     Send sentry notification
     Notification level is fatal by default
 
-    :param sentry_dsn: sentry DSN
-    :type sentry_dsn: string 
     :param message: sentry notification message
     :type message: string
-    :param environment: sentry environment
-    :type environment: string
-    :param level: notification level (fatal, error, warning, debug)
+    :param level: notification level (fatal, error, warning, info, debug)
     :type level: string
+    :param sentry_kwargs: dict of arguments to raven.Client (eg, "dsn")
+    :param message_kwargs: dict of arguments to sendMessage (eg, "fingerprint")
     """
 
-    template_fields = ('message',)
-    template_ext = ('.html',)
+    template_fields = ('message', )
     ui_color = '#e6faf9'
 
     @apply_defaults
-    def __init__(
-            self,
-            sentry_dsn,
-            message,
-            environment='',
-            level='fatal',
-            *args, **kwargs):
+    def __init__(self, message, level='info',
+                 sentry_kwargs=None, message_kwargs=None,
+                 *args, **kwargs):
         super(SentryOperator, self).__init__(*args, **kwargs)
-        self.sentry_dsn = sentry_dsn
         self.message = message
-        self.environment = environment
         self.level = level
-        
+        self.sentry_kwargs = sentry_kwargs
+        self.message_kwargs = message_kwargs
+        if message_kwargs is None:
+            self.message_kwargs = {}
 
     def execute(self, context):
-        send_msg_to_sentry(msg=self.message, environment=self.environment, level=self.level)
+        send_msg_to_sentry(message=self.message, level=self.level,
+                           sentry_kwargs=self.sentry_kwargs, **self.message_kwargs)

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1629,7 +1629,13 @@ class TaskInstance(Base):
                 "operator": type(self.task).__name__,
                 "task": [self.dag_id, self.task_id, str(self.execution_date)]
             },
-            "time_spent": int(self.duration * 1000)
+            "time_spent": int(self.duration * 1000),
+            "tags": {
+                "dag": self.dag_id,
+                "task": self.task_id,
+                "operator": type(self.task).__name__,
+                "error": type(exception).__name__
+            }
         }
         send_msg_to_sentry(message=message, **message_kwargs)
 

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1615,7 +1615,7 @@ class TaskInstance(Base):
             "fingerprint": [
                 self.dag_id,
                 self.task_id,
-                self.execution_date
+                str(self.execution_date)
             ],
             "extra": {
                 "try": self.try_number,
@@ -1623,10 +1623,11 @@ class TaskInstance(Base):
                 "log_url": self.log_url,
                 "mark_success_url": self.mark_success_url,
                 "duration": self.duration,
-                "started": self.start_date,
-                "ended": self.end_date,
-                "execution_date": self.execution_date,
+                "started": str(self.start_date),
+                "ended": str(self.end_date),
+                "execution_date": str(self.execution_date),
                 "operator": type(self.task).__name__,
+                "task": [self.dag_id, self.task_id, str(self.execution_date)]
             },
             "time_spent": int(self.duration * 1000)
         }

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1606,18 +1606,30 @@ class TaskInstance(Base):
         send an alert to sentry
         """
         task = self.task
-        exception = str(exception).replace('\n', '<br>')
-        try_ = task.retries + 1
-        body = (
-            "Airflow alert: {self}"
-            "Try {self.try_number} out of {try_}<br>"
-            "Exception:<br>{exception}<br>"
-            "Log: <a href='{self.log_url}'>Link</a><br>"
-            "Host: {self.hostname}<br>"
-            "Log file: {self.log_filepath}<br>"
-            "Mark success: <a href='{self.mark_success_url}'>Link</a><br>"
-        ).format(**locals())
-        send_msg_to_sentry(body)
+        exception = str(exception)
+        qualname = ".".join([self.dag_id, self.task_id])
+        status = "Retrying" if is_retry else "Failed"
+        message = "{status}}: {qualname}: {exception}".format(**locals())
+        message_kwargs = {
+            "level": "warning" if is_retry else "error",
+            "culprit": qualname,
+            "fingerprint": [
+                self.dag_id,
+                self.task_id,
+                self.execution_date
+            ],
+            "extra": {
+                "try": self.try_number,
+                "max_try": self.task.retries + 1,
+                "log_url": self.log_url,
+                "mark_success_url": self.mark_success_url,
+                "duration": self.duration,
+                "started": self.start_date,
+                "ended": self.end_date,
+                "execution_date": self.execution_date
+            }
+        }
+        send_msg_to_sentry(message=message, **message_kwargs)
 
     def set_duration(self):
         if self.end_date and self.start_date:

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -2023,6 +2023,7 @@ class BaseOperator(object):
             'email',
             'email_on_retry',
             'sentry_notify_on_retry',
+            'sentry_notify_on_failure',
             'retry_delay',
             'retry_exponential_backoff',
             'max_retry_delay',

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1615,7 +1615,7 @@ class TaskInstance(Base):
             "fingerprint": [
                 self.dag_id,
                 self.task_id,
-                str(self.execution_date)
+                type(exception).__name__
             ],
             "extra": {
                 "try": self.try_number,

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1618,8 +1618,7 @@ class TaskInstance(Base):
                 type(exception).__name__
             ],
             "extra": {
-                "try": self.try_number,
-                "max_try": self.task.retries + 1,
+                "try": [self.try_number, self.task.retries + 1],
                 "log_url": self.log_url,
                 "mark_success_url": self.mark_success_url,
                 "duration": self.duration,

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -1609,10 +1609,9 @@ class TaskInstance(Base):
         exception = str(exception)
         qualname = ".".join([self.dag_id, self.task_id])
         status = "Retrying" if is_retry else "Failed"
-        message = "{status}}: {qualname}: {exception}".format(**locals())
+        message = "{status}: {qualname}: {exception}".format(**locals())
         message_kwargs = {
             "level": "warning" if is_retry else "error",
-            "culprit": qualname,
             "fingerprint": [
                 self.dag_id,
                 self.task_id,
@@ -1626,8 +1625,10 @@ class TaskInstance(Base):
                 "duration": self.duration,
                 "started": self.start_date,
                 "ended": self.end_date,
-                "execution_date": self.execution_date
-            }
+                "execution_date": self.execution_date,
+                "operator": type(self.task).__name__,
+            },
+            "time_spent": int(self.duration * 1000)
         }
         send_msg_to_sentry(message=message, **message_kwargs)
 

--- a/airflow/utils/sentry.py
+++ b/airflow/utils/sentry.py
@@ -21,7 +21,10 @@ from __future__ import unicode_literals
 
 import logging
 
-from raven import Client as sentry_client
+try:
+    from raven import Client as sentry_client
+except ImportError:
+    logging.info("raven is not installed.")
 
 from airflow import configuration
 from airflow.exceptions import AirflowConfigException

--- a/airflow/utils/sentry.py
+++ b/airflow/utils/sentry.py
@@ -49,7 +49,7 @@ def get_sentry_client(dsn=None, site=None, name=None, release=None,
 
     def try_get_config(k):
         try:
-            return configuration.get_option("sentry", "sentry_{}".format(k.upper()))
+            return configuration.get_option("sentry", "sentry_{}".format(k))
         except AirflowConfigException:
             pass
 

--- a/airflow/utils/sentry.py
+++ b/airflow/utils/sentry.py
@@ -49,7 +49,7 @@ def get_sentry_client(dsn=None, site=None, name=None, release=None,
 
     def try_get_config(k):
         try:
-            return configuration.get_option("sentry", "sentry_{}".format(k))
+            return configuration.get("sentry", "sentry_{}".format(k))
         except AirflowConfigException:
             pass
 

--- a/airflow/utils/sentry.py
+++ b/airflow/utils/sentry.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import logging
-from airflow import configuration, __version__
+from airflow import configuration, settings
 from airflow.exceptions import AirflowConfigException
 
 HAS_RAVEN = False
@@ -63,7 +63,7 @@ def get_sentry_client(dsn=None, site=None, name=None, release=None,
     if release is None:
         release = try_get_config("release")
         if release is None:
-            dags_folder = try_get_config("core", "dags_folder")
+            dags_folder = settings.DAGS_FOLDER
             release = fetch_git_sha(dags_folder)
     if environment is None:
         environment = try_get_config("environment")

--- a/airflow/utils/sentry.py
+++ b/airflow/utils/sentry.py
@@ -26,6 +26,7 @@ from airflow.exceptions import AirflowConfigException
 HAS_RAVEN = False
 try:
     from raven import Client
+    from raven.versioning import fetch_git_sha
     HAS_RAVEN = True
 except ImportError:
     logging.info("raven is not installed.")
@@ -40,7 +41,7 @@ def get_sentry_client(dsn=None, site=None, name=None, release=None,
     :param dsn: Sentry DSN secret
     :param site: String identifying the installation
     :param name: Overrides the servers hostname if specified
-    :param release: Version string; defaults to airflow.__version__
+    :param release: Version string; defaults to SHA1 hash of the HEAD git commit in dags_folder
     :param environment: Environment string, eg staging or production
     :param tags: Dictionary of default tag:value pairs (merged when sending a message)
     :param kwargs: Extra arguments are passed to raven.Client()
@@ -62,7 +63,8 @@ def get_sentry_client(dsn=None, site=None, name=None, release=None,
     if release is None:
         release = try_get_config("release")
         if release is None:
-            release = __version__
+            dags_folder = try_get_config("core", "dags_folder")
+            release = fetch_git_sha(dags_folder)
     if environment is None:
         environment = try_get_config("environment")
     # tags is a dictionary and cannot be fetched from env/config


### PR DESCRIPTION
Generates structured sentry messages from task instance failures, instead of re-using the HTML mail template (which doesn't get rendered by sentry).

Task failures now get severity _warning_ for retryable fails, and _error_ if retries are exhausted. (I'd reserve _fatal_ for airflow dying, rather than DAG code). 